### PR TITLE
Removing duplicate LangVersion attribute

### DIFF
--- a/Source/ContentChecker/ContentChecker.csproj
+++ b/Source/ContentChecker/ContentChecker.csproj
@@ -21,7 +21,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -33,7 +32,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/ActivityEditor/AEWizard/AEWizard.csproj
+++ b/Source/Contrib/ActivityEditor/AEWizard/AEWizard.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -34,7 +33,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
+++ b/Source/Contrib/ActivityEditor/ActivityEditor/ActivityEditor.csproj
@@ -23,7 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
+++ b/Source/Contrib/ActivityEditor/LibAE/LibAE.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -34,7 +33,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/ContentManager/ContentManager.csproj
+++ b/Source/Contrib/ContentManager/ContentManager.csproj
@@ -23,7 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/DataCollector/DataCollector.csproj
+++ b/Source/Contrib/DataCollector/DataCollector.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -34,7 +33,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/DataConverter/DataConverter.csproj
+++ b/Source/Contrib/DataConverter/DataConverter.csproj
@@ -25,7 +25,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -37,7 +36,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/DataValidator/DataValidator.csproj
+++ b/Source/Contrib/DataValidator/DataValidator.csproj
@@ -21,7 +21,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -33,7 +32,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Contrib/TrackViewer/TrackViewer.csproj
+++ b/Source/Contrib/TrackViewer/TrackViewer.csproj
@@ -23,7 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -23,7 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -37,7 +36,6 @@
     <DocumentationFile>..\..\Program\Menu.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
     <NoWarn>1591</NoWarn>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.Common/ORTS.Common.csproj
+++ b/Source/ORTS.Common/ORTS.Common.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.Common.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.Content/ORTS.Content.csproj
+++ b/Source/ORTS.Content/ORTS.Content.csproj
@@ -21,7 +21,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -33,7 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.Content.xml</DocumentationFile>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.IO/ORTS.IO.csproj
+++ b/Source/ORTS.IO/ORTS.IO.csproj
@@ -21,7 +21,6 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -33,7 +32,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.IO.xml</DocumentationFile>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.Menu/ORTS.Menu.csproj
+++ b/Source/ORTS.Menu/ORTS.Menu.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.Menu.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.Settings/ORTS.Settings.csproj
+++ b/Source/ORTS.Settings/ORTS.Settings.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.Settings.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/ORTS.Updater/ORTS.Updater.csproj
+++ b/Source/ORTS.Updater/ORTS.Updater.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\ORTS.Updater.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
+++ b/Source/Orts.Formats.Msts/Orts.Formats.Msts.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Orts.Formats.Msts.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
+++ b/Source/Orts.Formats.OR/Orts.Formats.OR.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Orts.Formats.OR.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
+++ b/Source/Orts.Parsers.Msts/Orts.Parsers.Msts.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Orts.Parsers.Msts.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
+++ b/Source/Orts.Parsers.OR/Orts.Parsers.OR.csproj
@@ -21,7 +21,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -34,7 +33,6 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Orts.Simulation/Orts.Simulation.csproj
+++ b/Source/Orts.Simulation/Orts.Simulation.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Orts.Simulation.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/RunActivity/RunActivity.csproj
+++ b/Source/RunActivity/RunActivity.csproj
@@ -23,7 +23,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -37,7 +36,6 @@
     <DocumentationFile>..\..\Program\RunActivity.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
     <NoWarn>1591</NoWarn>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Tests.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Source/Updater/Updater.csproj
+++ b/Source/Updater/Updater.csproj
@@ -22,7 +22,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -35,7 +34,6 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\Program\Updater.xml</DocumentationFile>
     <PlatformTarget>x86</PlatformTarget>
-    <LangVersion>6</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Likely as result of a merge, LangVersion attribute had been in there twice for each config. While VS only used the higher one, still removed the other one to ensure consistency.