### PR TITLE
Removing separate File Creation

### DIFF
--- a/Source/RunActivity/Viewer3D/OpenAL.cs
+++ b/Source/RunActivity/Viewer3D/OpenAL.cs
@@ -439,10 +439,6 @@ namespace Orts.Viewer3D
             string configFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "alsoft.ini");
             try
             {
-                if (!File.Exists(configFile))
-                {
-                    File.CreateText(configFile);
-                }
                 StringBuilder result = new StringBuilder(255);
                 if (ORTS.Common.NativeMethods.GetPrivateProfileString("General", "sources", string.Empty, result, 255, configFile) > 0)
                 {


### PR DESCRIPTION
In some cases there seem a race condition to happen when the file is new created, setting the initial value would not be honored before second start of the game.
As WritePrivateProfileString will also just create the file if not existing, the prior check and creation is not necessary